### PR TITLE
fix: upgrade openai to v1.x with API migration

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ python-telegram-bot[all]>=20.0
 
 # AI
 google-genai>=1.51.0
-openai>=0.27.0
+openai>=1.0.0
 
 # 数据库
 aiosqlite>=0.19.0


### PR DESCRIPTION
## 迁移内容

### 变更
- 将 `openai` 依赖版本从 `>=0.27.0` 升级到 `>=1.0.0`

### 兼容性分析
经过代码审查，当前代码已完全使用 openai v1.x API 模式：
- ✅ 客户端初始化使用 `AsyncOpenAI(api_key, base_url)`
- ✅ Chat Completion 调用使用 `client.chat.completions.create()`
- ✅ 模型列表使用 `client.models.list()`
- ✅ 响应解析使用 `response.choices[0].message.content`

**无需修改任何 Python 代码** - API 调用完全兼容。

### 测试
- 所有 OpenAI API 调用模式已验证符合 v1.x 规范
- `AsyncOpenAI` 客户端初始化方式正确
- `chat.completions.create` 参数格式正确
- `models.list()` 返回格式正确

### 影响范围
- 仅修改 `requirements.txt` 中的版本约束
- 无运行时行为变化
- 向后兼容 v1.x 所有版本